### PR TITLE
Fix: Run predicate against array and elements for production environments

### DIFF
--- a/src/checkField.js
+++ b/src/checkField.js
@@ -30,7 +30,8 @@ export default function checkField(fieldVal, rule) {
   if (Array.isArray(fieldVal)) {
     return isObject(rule)
       ? fieldVal.some(val => checkField(val, rule)) || parseObjectRule(rule)
-      : fieldVal.some(val => checkField(val, rule)) || predicate[rule](fieldVal);
+      : fieldVal.some(val => checkField(val, rule)) ||
+        predicate[rule](fieldVal);
   } else if (isObject(rule)) {
     // Complicated rule - like { greater then 10 }
     return parseObjectRule(rule, fieldVal);

--- a/src/conditionsMeet.js
+++ b/src/conditionsMeet.js
@@ -8,6 +8,7 @@ export default function conditionsMeet(conditions, formData) {
     toError(
       `Rule ${JSON.stringify(conditions)} with ${formData} can't be processed`
     );
+    return false;
   }
   return Object.keys(conditions).every(ref => {
     let refCondition = conditions[ref];


### PR DESCRIPTION
My apologies I was unaware your toError util function was none blocking in production, conditionMeets changed to return after toError invocation