### PR TITLE
Fixes #18

### DIFF
--- a/src/conditionsMeet.js
+++ b/src/conditionsMeet.js
@@ -35,8 +35,8 @@ export default function conditionsMeet(condition, formData) {
     } else {
       let refVal = selectRef(ref, formData);
       if (Array.isArray(refVal)) {
-        let condMeatOnce = refVal.some(val =>
-          conditionsMeet(refCondition, val)
+        let condMeatOnce = refVal.some(
+          val => (isObject(val) ? conditionsMeet(refCondition, val) : false)
         );
         // It's either true for an element in an array or for the whole array
         return (

--- a/test/conditionsMeet.test.js
+++ b/test/conditionsMeet.test.js
@@ -14,6 +14,17 @@ test("run predicate against array and elements", () => {
   expect(conditionsMeet(condition, [])).toBeTruthy();
 });
 
+test("handles array of non-objects", () => {
+  let condition = {
+    options: {
+      contains: "foo",
+    },
+  };
+  expect(conditionsMeet(condition, { options: ["bar"] })).toBeFalsy();
+  expect(conditionsMeet(condition, { options: [] })).toBeFalsy();
+  expect(conditionsMeet(condition, { options: ["foo", "bar"] })).toBeTruthy();
+});
+
 test("single line", () => {
   let condition = {
     firstName: "empty",


### PR DESCRIPTION
conditionsMeet can handle testing values that are arrays of strings.
However it still fails to test arrays of numbers.