### PR TITLE
Imports predicate/dist/predicate (fixes #23)

### DIFF
--- a/src/checkField.js
+++ b/src/checkField.js
@@ -1,4 +1,4 @@
-import predicate from "predicate";
+import predicate from "predicate/dist/predicate";
 import { isObject } from "./utils";
 
 import { AND, NOT, OR } from "./constants";

--- a/src/validation.js
+++ b/src/validation.js
@@ -1,4 +1,4 @@
-import predicate from "predicate";
+import predicate from "predicate/dist/predicate";
 import {
   flatMap,
   isObject,

--- a/test/predicate.test.js
+++ b/test/predicate.test.js
@@ -1,4 +1,4 @@
-import predicate from "predicate";
+import predicate from "predicate/dist/predicate";
 import Engine from "../src/Engine";
 
 test("equal work with same strings", function() {

--- a/test/validation.predicates.test.js
+++ b/test/validation.predicates.test.js
@@ -1,4 +1,4 @@
-import predicate from "predicate";
+import predicate from "predicate/dist/predicate";
 import { listInvalidPredicates } from "../src/validation";
 
 let schema = {


### PR DESCRIPTION
As specified in #23, this imports `predicate/dist/predicate` instead of just `predicate` to make sure this projects builds successfully in an ES5 environment, such as create-react-app.