### PR TITLE
Updating Tests to show extending predicates as in docs does not work

### DIFF
--- a/test/predicate.test.js
+++ b/test/predicate.test.js
@@ -27,7 +27,13 @@ let engine = new Engine([
     conditions: { age: { range: [20, 40] } },
     event: "hit",
   },
-]);
+], {
+  properties: {
+    age: {
+      type: 'number'
+    }
+  }  
+});
 
 test("not in range left", () => {
   return engine.run({ age: 10 }).then(events => expect(events).toEqual([]));


### PR DESCRIPTION
As described in #31 I found out, that the Test case is incomplete and indeed throws an error when correctly defined using a schema. The validation then seems to throw an error. So the way it is described in the docs, does not work properly.